### PR TITLE
Secret PR don't disclose

### DIFF
--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -585,39 +585,13 @@ and this is thread %s
         self._destinationSrv is what was given as first parameter of the init serviceName
 
         newKwargs is an updated copy of kwargs:
-          * kwargs has already been updated by all the initialization functions
-          * if a delegated DN is not set, but is found in __threadConfig or in the info returned by the protocol
-            sanitiy check, then we replace it (KW_DELEGATED_DN)
-          * Same goes for the delegated group KW_DELEGATED_GROUP. In the case of a host,
-            the value is the same as for VAL_EXTRA_CREDENTIALS_HOST
-          * if set, we remove the useCertificates (KW_USE_CERTIFICATES) in newKwargs (not sure to know why)
+          * if set, we remove the useCertificates (KW_USE_CERTIFICATES) in newKwargs
 
         This method is just used to return information in case of error in the InnerRPCClient
     """
     newKwargs = dict(self.kwargs)
-    # Set DN
-    tDN, tGroup = self.__threadConfig.getID()
-    if self.KW_DELEGATED_DN not in newKwargs:
-      if tDN:
-        newKwargs[self.KW_DELEGATED_DN] = tDN
-      elif 'DN' in self.__idDict:
-        newKwargs[self.KW_DELEGATED_DN] = self.__idDict['DN']
-    # Discover group
-    if self.KW_DELEGATED_GROUP not in newKwargs:
-      if 'group' in self.__idDict:
-        newKwargs[self.KW_DELEGATED_GROUP] = self.__idDict['group']
-      elif tGroup:
-        newKwargs[self.KW_DELEGATED_GROUP] = tGroup
-      else:
-        if self.KW_DELEGATED_DN in newKwargs:
-          if CS.getUsernameForDN(newKwargs[self.KW_DELEGATED_DN])['OK']:
-            result = CS.findDefaultGroupForDN(newKwargs[self.KW_DELEGATED_DN])
-            if result['OK']:
-              newKwargs[self.KW_DELEGATED_GROUP] = result['Value']
-          if CS.getHostnameForDN(newKwargs[self.KW_DELEGATED_DN])['OK']:
-            newKwargs[self.KW_DELEGATED_GROUP] = self.VAL_EXTRA_CREDENTIALS_HOST
-
-    # Not sure why one would want to remove that...
+    # Remove useCertificates as the forwarder of the call will have to
+    # independently decide whether to use their cert or not anyway.
     if 'useCertificates' in newKwargs:
       del newKwargs['useCertificates']
     return (self._destinationSrv, newKwargs)

--- a/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
+++ b/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
@@ -60,6 +60,10 @@ class ForwardDISET( OperationHandlerBase ):
       self.operation.Status = "Failed"
       return S_ERROR( str( error ) )
 
+    # Ensure the forwarded request is done on behalf of the request owner
+    decode[0][1]['delegatedDN'] = self.request.OwnerDN
+    decode[0][1]['delegatedGroup'] = self.request.OwnerGroup
+
     # ForwardDiset is supposed to be used with a host certificate
     useServerCertificate = gConfig.useServerCertificate()
     gConfigurationData.setOptionInCFG( '/DIRAC/Security/UseServerCertificate', 'true' )

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -22,7 +22,8 @@ from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
 from DIRAC.RequestManagementSystem.DB.RequestDB import RequestDB
 
-class ReqManagerHandler( RequestHandler ):
+
+class ReqManagerHandler(RequestHandler):
   """
   .. class:: ReqManagerHandler
 
@@ -34,183 +35,201 @@ class ReqManagerHandler( RequestHandler ):
   __requestDB = None
 
   @classmethod
-  def initializeHandler( cls, serviceInfoDict ):
+  def initializeHandler(cls, serviceInfoDict):
     """ initialize handler """
 
     try:
       cls.__requestDB = RequestDB()
-    except RuntimeError, error:
-      gLogger.exception( error )
-      return S_ERROR( error )
+    except RuntimeError as error:
+      gLogger.exception(error)
+      return S_ERROR(error)
 
     # If there is a constant delay to be applied to each request
-    cls.constantRequestDelay = getServiceOption( serviceInfoDict, 'ConstantRequestDelay', 0 )
+    cls.constantRequestDelay = getServiceOption(serviceInfoDict, 'ConstantRequestDelay', 0)
 
     # # create tables for empty db
     return cls.__requestDB.createTables()
 
   # # helper functions
   @classmethod
-  def validate( cls, request ):
+  def validate(cls, request):
     """ request validation """
     if not cls.__validator:
       cls.__validator = RequestValidator()
-    return cls.__validator.validate( request )
+    return cls.__validator.validate(request)
 
-  types_getRequestIDForName = [ StringTypes ]
+  types_getRequestIDForName = [StringTypes]
+
   @classmethod
-  def export_getRequestIDForName( cls, requestName ):
+  def export_getRequestIDForName(cls, requestName):
     """ get requestID for given :requestName: """
-    if type( requestName ) in StringTypes:
-      result = cls.__requestDB.getRequestIDForName( requestName )
+    if type(requestName) in StringTypes:
+      result = cls.__requestDB.getRequestIDForName(requestName)
       if not result["OK"]:
         return result
       requestID = result["Value"]
-    return S_OK( requestID )
+    return S_OK(requestID)
 
+  types_cancelRequest = [(IntType, LongType)]
 
-
-  types_cancelRequest = [ ( IntType, LongType ) ]
   @classmethod
-  def export_cancelRequest( cls , requestID ):
+  def export_cancelRequest(cls, requestID):
     """ Cancel a request """
-    return cls.__requestDB.cancelRequest( requestID )
+    return cls.__requestDB.cancelRequest(requestID)
 
+  types_putRequest = [StringTypes]
 
-  types_putRequest = [ StringTypes ]
-  @classmethod
-  def export_putRequest( cls, requestJSON ):
+  def export_putRequest(self, requestJSON):
     """ put a new request into RequestDB
 
     :param cls: class ref
     :param str requestJSON: request serialized to JSON format
     """
-    requestDict = json.loads( requestJSON )
-    requestName = requestDict.get( "RequestID", requestDict.get( 'RequestName', "***UNKNOWN***" ) )
-    request = Request( requestDict )
+    requestDict = json.loads(requestJSON)
+    requestName = requestDict.get("RequestID", requestDict.get('RequestName', "***UNKNOWN***"))
+    request = Request(requestDict)
+
+    # Check whether the credentials in the Requests are correct and allowed to be set
+    isAuthorized = RequestValidator.setAndCheckRequestOwner(request, self.getRemoteCredentials())
+
+    if not isAuthorized:
+      return S_ERROR("Credentials in the requests are not allowed")
+
     optimized = request.optimize()
-    if optimized.get( "Value", False ):
-      gLogger.debug( "putRequest: request was optimized" )
+    if optimized.get("Value", False):
+      gLogger.debug("putRequest: request was optimized")
     else:
-      gLogger.debug( "putRequest: request unchanged", optimized.get( "Message", "Nothing could be optimized" ) )
+      gLogger.debug(
+          "putRequest: request unchanged",
+          optimized.get(
+              "Message",
+              "Nothing could be optimized"))
 
-    valid = cls.validate( request )
+    valid = self.validate(request)
     if not valid["OK"]:
-      gLogger.error( "putRequest: request %s not valid: %s" % ( requestName, valid["Message"] ) )
+      gLogger.error("putRequest: request %s not valid: %s" % (requestName, valid["Message"]))
       return valid
-
 
     # If NotBefore is not set or user defined, we calculate its value
 
-    now = datetime.datetime.utcnow().replace( microsecond = 0 )
-    extraDelay = datetime.timedelta( 0 )
-    if request.Status not in Request.FINAL_STATES and ( not request.NotBefore or request.NotBefore < now ) :
+    now = datetime.datetime.utcnow().replace(microsecond=0)
+    extraDelay = datetime.timedelta(0)
+    if request.Status not in Request.FINAL_STATES and (
+            not request.NotBefore or request.NotBefore < now):
       # We don't delay if it is the first insertion
-      if getattr( request, 'RequestID', 0 ):
+      if getattr(request, 'RequestID', 0):
         # If it is a constant delay, just set it
-        if cls.constantRequestDelay:
-          extraDelay = datetime.timedelta( minutes = cls.constantRequestDelay )
+        if self.constantRequestDelay:
+          extraDelay = datetime.timedelta(minutes=self.constantRequestDelay)
         else:
           # If there is a waiting Operation with Files
-          op = request.getWaiting().get( 'Value' )
-          if op and len( op ):
-            attemptList = [ opFile.Attempt for opFile in op if opFile.Status == "Waiting" ]
+          op = request.getWaiting().get('Value')
+          if op and len(op):
+            attemptList = [opFile.Attempt for opFile in op if opFile.Status == "Waiting"]
             if attemptList:
-              maxWaitingAttempt = max( [ opFile.Attempt for opFile in op if opFile.Status == "Waiting" ] )
+              maxWaitingAttempt = max(
+                  [opFile.Attempt for opFile in op if opFile.Status == "Waiting"])
               # In case it is the first attempt, extraDelay is 0
               # maxWaitingAttempt can be None if the operation has no File, like the ForwardDiset
-              extraDelay = datetime.timedelta( minutes = 2 * math.log( maxWaitingAttempt )  if maxWaitingAttempt else 0 )
+              extraDelay = datetime.timedelta(
+                  minutes=2 * math.log(maxWaitingAttempt) if maxWaitingAttempt else 0)
 
         request.NotBefore = now + extraDelay
 
-    gLogger.info( "putRequest: request %s not before %s (extra delay %s)" % ( request.RequestName, request.NotBefore, extraDelay ) )
+    gLogger.info("putRequest: request %s not before %s (extra delay %s)" %
+                 (request.RequestName, request.NotBefore, extraDelay))
 
     requestName = request.RequestName
-    gLogger.info( "putRequest: Attempting to set request '%s'" % requestName )
-    return cls.__requestDB.putRequest( request )
+    gLogger.info("putRequest: Attempting to set request '%s'" % requestName)
+    return self.__requestDB.putRequest(request)
 
-  types_getScheduledRequest = [ ( IntType, LongType ) ]
+  types_getScheduledRequest = [(IntType, LongType)]
+
   @classmethod
-  def export_getScheduledRequest( cls , operationID ):
+  def export_getScheduledRequest(cls, operationID):
     """ read scheduled request given operationID """
-    scheduled = cls.__requestDB.getScheduledRequest( operationID )
+    scheduled = cls.__requestDB.getScheduledRequest(operationID)
     if not scheduled["OK"]:
-      gLogger.error( "getScheduledRequest: %s" % scheduled["Message"] )
+      gLogger.error("getScheduledRequest: %s" % scheduled["Message"])
       return scheduled
     if not scheduled["Value"]:
       return S_OK()
     requestJSON = scheduled["Value"].toJSON()
     if not requestJSON["OK"]:
-      gLogger.error( "getScheduledRequest: %s" % requestJSON["Message"] )
+      gLogger.error("getScheduledRequest: %s" % requestJSON["Message"])
     return requestJSON
 
   types_getDBSummary = []
+
   @classmethod
-  def export_getDBSummary( cls ):
+  def export_getDBSummary(cls):
     """ Get the summary of requests in the Request DB """
     return cls.__requestDB.getDBSummary()
 
-  types_getRequest = [ ( LongType, IntType ) ]
+  types_getRequest = [(LongType, IntType)]
+
   @classmethod
-  def export_getRequest( cls, requestID = 0 ):
+  def export_getRequest(cls, requestID=0):
     """ Get a request of given type from the database """
-    getRequest = cls.__requestDB.getRequest( requestID )
+    getRequest = cls.__requestDB.getRequest(requestID)
     if not getRequest["OK"]:
-      gLogger.error( "getRequest: %s" % getRequest["Message"] )
+      gLogger.error("getRequest: %s" % getRequest["Message"])
       return getRequest
     if getRequest["Value"]:
       getRequest = getRequest["Value"]
       toJSON = getRequest.toJSON()
       if not toJSON["OK"]:
-        gLogger.error( toJSON["Message"] )
+        gLogger.error(toJSON["Message"])
       return toJSON
     return S_OK()
 
+  types_getBulkRequests = [IntType, BooleanType]
 
-  types_getBulkRequests = [ IntType, BooleanType ]
   @classmethod
-  def export_getBulkRequests( cls, numberOfRequest, assigned ):
+  def export_getBulkRequests(cls, numberOfRequest, assigned):
     """ Get a request of given type from the database
         :param numberOfRequest : size of the bulk (default 10)
 
         :return S_OK( {Failed : message, Successful : list of Request.toJSON()} )
     """
-    getRequests = cls.__requestDB.getBulkRequests( numberOfRequest = numberOfRequest, assigned = assigned )
+    getRequests = cls.__requestDB.getBulkRequests(
+        numberOfRequest=numberOfRequest, assigned=assigned)
     if not getRequests["OK"]:
-      gLogger.error( "getRequests: %s" % getRequests["Message"] )
+      gLogger.error("getRequests: %s" % getRequests["Message"])
       return getRequests
     if getRequests["Value"]:
       getRequests = getRequests["Value"]
-      toJSONDict = {"Successful" : {}, "Failed" : {}}
+      toJSONDict = {"Successful": {}, "Failed": {}}
 
       for rId in getRequests:
         toJSON = getRequests[rId].toJSON()
         if not toJSON["OK"]:
-          gLogger.error( toJSON["Message"] )
+          gLogger.error(toJSON["Message"])
           toJSONDict["Failed"][rId] = toJSON["Message"]
         else:
           toJSONDict["Successful"][rId] = toJSON["Value"]
-      return S_OK( toJSONDict )
+      return S_OK(toJSONDict)
     return S_OK()
 
+  types_peekRequest = [(LongType, IntType)]
 
-  types_peekRequest = [ ( LongType, IntType ) ]
   @classmethod
-  def export_peekRequest( cls, requestID = 0 ):
+  def export_peekRequest(cls, requestID=0):
     """ peek request given its id """
-    peekRequest = cls.__requestDB.peekRequest( requestID )
+    peekRequest = cls.__requestDB.peekRequest(requestID)
     if not peekRequest["OK"]:
-      gLogger.error( "peekRequest: %s" % peekRequest["Message"] )
+      gLogger.error("peekRequest: %s" % peekRequest["Message"])
       return peekRequest
     if peekRequest["Value"]:
       peekRequest = peekRequest["Value"].toJSON()
       if not peekRequest["OK"]:
-        gLogger.error( peekRequest["Message"] )
+        gLogger.error(peekRequest["Message"])
     return peekRequest
 
-  types_getRequestSummaryWeb = [ DictType, ListType, IntType, IntType ]
+  types_getRequestSummaryWeb = [DictType, ListType, IntType, IntType]
+
   @classmethod
-  def export_getRequestSummaryWeb( cls, selectDict, sortList, startItem, maxItems ):
+  def export_getRequestSummaryWeb(cls, selectDict, sortList, startItem, maxItems):
     """ Returns a list of Request for the web portal
 
         :param dict selectDict: parameter on which to restrain the query {key : Value}
@@ -221,23 +240,24 @@ class ReqManagerHandler( RequestHandler ):
         :param int startItem: start item (for pagination)
         :param int maxItems: max items (for pagination)
     """
-    return cls.__requestDB.getRequestSummaryWeb( selectDict, sortList, startItem, maxItems )
+    return cls.__requestDB.getRequestSummaryWeb(selectDict, sortList, startItem, maxItems)
 
-  types_getDistinctValuesWeb = [ StringTypes ]
+  types_getDistinctValuesWeb = [StringTypes]
+
   @classmethod
-  def export_getDistinctValuesWeb( cls, attribute ):
+  def export_getDistinctValuesWeb(cls, attribute):
     """ Get distinct values for a given request attribute. 'Type' is interpreted as
         the operation type """
 
     tableName = 'Request'
     if attribute == 'Type':
       tableName = 'Operation'
-    return cls.__requestDB.getDistinctValues( tableName, attribute )
+    return cls.__requestDB.getDistinctValues(tableName, attribute)
 
+  types_getRequestCountersWeb = [StringTypes, DictType]
 
-  types_getRequestCountersWeb = [ StringTypes, DictType ]
   @classmethod
-  def export_getRequestCountersWeb( cls, groupingAttribute, selectDict ):
+  def export_getRequestCountersWeb(cls, groupingAttribute, selectDict):
     """ For the web portal.
         Returns a dictionary {value : counts} for a given key.
         The key can be any field from the RequestTable. or "Type",
@@ -247,73 +267,87 @@ class ReqManagerHandler( RequestHandler ):
         :param selectDict : selection criteria
     """
 
-    return cls.__requestDB.getRequestCountersWeb( groupingAttribute, selectDict )
+    return cls.__requestDB.getRequestCountersWeb(groupingAttribute, selectDict)
 
-  types_deleteRequest = [ ( IntType, LongType ) ]
+  types_deleteRequest = [(IntType, LongType)]
+
   @classmethod
-  def export_deleteRequest( cls, requestID ):
+  def export_deleteRequest(cls, requestID):
     """ Delete the request with the supplied ID"""
-    return cls.__requestDB.deleteRequest( requestID )
+    return cls.__requestDB.deleteRequest(requestID)
 
-  types_getRequestIDsList = [ ListType, IntType, StringTypes ]
+  types_getRequestIDsList = [ListType, IntType, StringTypes]
+
   @classmethod
-  def export_getRequestIDsList( cls, statusList = None, limit = None, since = None, until = None, getJobID = False ):
+  def export_getRequestIDsList(
+          cls,
+          statusList=None,
+          limit=None,
+          since=None,
+          until=None,
+          getJobID=False):
     """ get requests' IDs with status in :statusList: """
-    statusList = statusList if statusList else list( Request.FINAL_STATES )
+    statusList = statusList if statusList else list(Request.FINAL_STATES)
     limit = limit if limit else 100
     since = since if since else ""
     until = until if until else ""
-    reqIDsList = cls.__requestDB.getRequestIDsList( statusList, limit, since = since, until = until, getJobID = getJobID )
+    reqIDsList = cls.__requestDB.getRequestIDsList(
+        statusList, limit, since=since, until=until, getJobID=getJobID)
     if not reqIDsList["OK"]:
-      gLogger.error( "getRequestIDsList: %s" % reqIDsList["Message"] )
+      gLogger.error("getRequestIDsList: %s" % reqIDsList["Message"])
     return reqIDsList
 
-  types_getRequestIDsForJobs = [ ListType ]
-  @classmethod
-  def export_getRequestIDsForJobs( cls, jobIDs ):
-    """ Select the request IDs for supplied jobIDs """
-    return cls.__requestDB.getRequestIDsForJobs( jobIDs )
+  types_getRequestIDsForJobs = [ListType]
 
-  types_readRequestsForJobs = [ ListType ]
   @classmethod
-  def export_readRequestsForJobs( cls, jobIDs ):
+  def export_getRequestIDsForJobs(cls, jobIDs):
+    """ Select the request IDs for supplied jobIDs """
+    return cls.__requestDB.getRequestIDsForJobs(jobIDs)
+
+  types_readRequestsForJobs = [ListType]
+
+  @classmethod
+  def export_readRequestsForJobs(cls, jobIDs):
     """ read requests for jobs given list of jobIDs """
-    requests = cls.__requestDB.readRequestsForJobs( jobIDs )
+    requests = cls.__requestDB.readRequestsForJobs(jobIDs)
     if not requests["OK"]:
-      gLogger.error( "readRequestsForJobs: %s" % requests["Message"] )
+      gLogger.error("readRequestsForJobs: %s" % requests["Message"])
       return requests
     for jobID, request in requests["Value"]["Successful"].items():
       requests["Value"]["Successful"][jobID] = request.toJSON()["Value"]
     return requests
 
-  types_getDigest = [ ( IntType, LongType ) ]
+  types_getDigest = [(IntType, LongType)]
+
   @classmethod
-  def export_getDigest( cls, requestID ):
+  def export_getDigest(cls, requestID):
     """ get digest for a request given its id
 
     :param str requestID: request's id
     :return: S_OK( json_str )
     """
-    return cls.__requestDB.getDigest( requestID )
+    return cls.__requestDB.getDigest(requestID)
 
-  types_getRequestStatus = [ ( IntType, LongType ) ]
+  types_getRequestStatus = [(IntType, LongType)]
+
   @classmethod
-  def export_getRequestStatus( cls, requestID ):
+  def export_getRequestStatus(cls, requestID):
     """ get request status given its id """
-    status = cls.__requestDB.getRequestStatus( requestID )
+    status = cls.__requestDB.getRequestStatus(requestID)
     if not status["OK"]:
-      gLogger.error( "getRequestStatus: %s" % status["Message"] )
+      gLogger.error("getRequestStatus: %s" % status["Message"])
     return status
 
-  types_getRequestFileStatus = [ [ IntType, LongType ], list( StringTypes ) + [ListType] ]
+  types_getRequestFileStatus = [[IntType, LongType], list(StringTypes) + [ListType]]
+
   @classmethod
-  def export_getRequestFileStatus( cls, requestID, lfnList ):
+  def export_getRequestFileStatus(cls, requestID, lfnList):
     """ get request file status for a given LFNs list and requestID """
-    if type( lfnList ) == str:
+    if isinstance(lfnList, str):
       lfnList = [lfnList]
-    res = cls.__requestDB.getRequestFileStatus( requestID, lfnList )
+    res = cls.__requestDB.getRequestFileStatus(requestID, lfnList)
     if not res["OK"]:
-      gLogger.error( "getRequestFileStatus: %s" % res["Message"] )
+      gLogger.error("getRequestFileStatus: %s" % res["Message"])
     return res
 
 #   types_getRequestName = [ ( IntType, LongType ) ]
@@ -325,11 +359,12 @@ class ReqManagerHandler( RequestHandler ):
 #       gLogger.error( "getRequestName: %s" % requestName["Message"] )
 #     return requestName
 
-  types_getRequestInfo = [ [ IntType, LongType ] ]
+  types_getRequestInfo = [[IntType, LongType]]
+
   @classmethod
-  def export_getRequestInfo( cls, requestID ):
+  def export_getRequestInfo(cls, requestID):
     """ get request info for a given requestID """
-    requestInfo = cls.__requestDB.getRequestInfo( requestID )
+    requestInfo = cls.__requestDB.getRequestInfo(requestID)
     if not requestInfo["OK"]:
-      gLogger.error( "getRequestInfo: %s" % requestInfo["Message"] )
+      gLogger.error("getRequestInfo: %s" % requestInfo["Message"])
     return requestInfo

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -16,6 +16,7 @@ import math
 # # from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
+from DIRAC.Core.Utilities import DErrno
 # # from RMS
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
@@ -92,7 +93,7 @@ class ReqManagerHandler(RequestHandler):
     isAuthorized = RequestValidator.setAndCheckRequestOwner(request, self.getRemoteCredentials())
 
     if not isAuthorized:
-      return S_ERROR("Credentials in the requests are not allowed")
+      return S_ERROR(DErrno.ENOAUTH, "Credentials in the requests are not allowed")
 
     optimized = request.optimize()
     if optimized.get("Value", False):

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -13,7 +13,6 @@ __RCSID__ = "$Id$"
 import json
 import datetime
 import math
-from types import DictType, IntType, LongType, ListType, StringTypes, BooleanType
 # # from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
@@ -58,26 +57,26 @@ class ReqManagerHandler(RequestHandler):
       cls.__validator = RequestValidator()
     return cls.__validator.validate(request)
 
-  types_getRequestIDForName = [StringTypes]
+  types_getRequestIDForName = [basestring]
 
   @classmethod
   def export_getRequestIDForName(cls, requestName):
     """ get requestID for given :requestName: """
-    if type(requestName) in StringTypes:
+    if isinstance(requestName, basestring):
       result = cls.__requestDB.getRequestIDForName(requestName)
       if not result["OK"]:
         return result
       requestID = result["Value"]
     return S_OK(requestID)
 
-  types_cancelRequest = [(IntType, LongType)]
+  types_cancelRequest = [(int, long)]
 
   @classmethod
   def export_cancelRequest(cls, requestID):
     """ Cancel a request """
     return cls.__requestDB.cancelRequest(requestID)
 
-  types_putRequest = [StringTypes]
+  types_putRequest = [basestring]
 
   def export_putRequest(self, requestJSON):
     """ put a new request into RequestDB
@@ -143,7 +142,7 @@ class ReqManagerHandler(RequestHandler):
     gLogger.info("putRequest: Attempting to set request '%s'" % requestName)
     return self.__requestDB.putRequest(request)
 
-  types_getScheduledRequest = [(IntType, LongType)]
+  types_getScheduledRequest = [(int, long)]
 
   @classmethod
   def export_getScheduledRequest(cls, operationID):
@@ -166,7 +165,7 @@ class ReqManagerHandler(RequestHandler):
     """ Get the summary of requests in the Request DB """
     return cls.__requestDB.getDBSummary()
 
-  types_getRequest = [(LongType, IntType)]
+  types_getRequest = [(long, int)]
 
   @classmethod
   def export_getRequest(cls, requestID=0):
@@ -183,7 +182,7 @@ class ReqManagerHandler(RequestHandler):
       return toJSON
     return S_OK()
 
-  types_getBulkRequests = [IntType, BooleanType]
+  types_getBulkRequests = [int, bool]
 
   @classmethod
   def export_getBulkRequests(cls, numberOfRequest, assigned):
@@ -211,7 +210,7 @@ class ReqManagerHandler(RequestHandler):
       return S_OK(toJSONDict)
     return S_OK()
 
-  types_peekRequest = [(LongType, IntType)]
+  types_peekRequest = [(long, int)]
 
   @classmethod
   def export_peekRequest(cls, requestID=0):
@@ -226,7 +225,7 @@ class ReqManagerHandler(RequestHandler):
         gLogger.error(peekRequest["Message"])
     return peekRequest
 
-  types_getRequestSummaryWeb = [DictType, ListType, IntType, IntType]
+  types_getRequestSummaryWeb = [dict, list, int, int]
 
   @classmethod
   def export_getRequestSummaryWeb(cls, selectDict, sortList, startItem, maxItems):
@@ -242,7 +241,7 @@ class ReqManagerHandler(RequestHandler):
     """
     return cls.__requestDB.getRequestSummaryWeb(selectDict, sortList, startItem, maxItems)
 
-  types_getDistinctValuesWeb = [StringTypes]
+  types_getDistinctValuesWeb = [basestring]
 
   @classmethod
   def export_getDistinctValuesWeb(cls, attribute):
@@ -254,7 +253,7 @@ class ReqManagerHandler(RequestHandler):
       tableName = 'Operation'
     return cls.__requestDB.getDistinctValues(tableName, attribute)
 
-  types_getRequestCountersWeb = [StringTypes, DictType]
+  types_getRequestCountersWeb = [basestring, dict]
 
   @classmethod
   def export_getRequestCountersWeb(cls, groupingAttribute, selectDict):
@@ -269,14 +268,14 @@ class ReqManagerHandler(RequestHandler):
 
     return cls.__requestDB.getRequestCountersWeb(groupingAttribute, selectDict)
 
-  types_deleteRequest = [(IntType, LongType)]
+  types_deleteRequest = [(int, long)]
 
   @classmethod
   def export_deleteRequest(cls, requestID):
     """ Delete the request with the supplied ID"""
     return cls.__requestDB.deleteRequest(requestID)
 
-  types_getRequestIDsList = [ListType, IntType, StringTypes]
+  types_getRequestIDsList = [list, int, basestring]
 
   @classmethod
   def export_getRequestIDsList(
@@ -297,14 +296,14 @@ class ReqManagerHandler(RequestHandler):
       gLogger.error("getRequestIDsList: %s" % reqIDsList["Message"])
     return reqIDsList
 
-  types_getRequestIDsForJobs = [ListType]
+  types_getRequestIDsForJobs = [list]
 
   @classmethod
   def export_getRequestIDsForJobs(cls, jobIDs):
     """ Select the request IDs for supplied jobIDs """
     return cls.__requestDB.getRequestIDsForJobs(jobIDs)
 
-  types_readRequestsForJobs = [ListType]
+  types_readRequestsForJobs = [list]
 
   @classmethod
   def export_readRequestsForJobs(cls, jobIDs):
@@ -317,7 +316,7 @@ class ReqManagerHandler(RequestHandler):
       requests["Value"]["Successful"][jobID] = request.toJSON()["Value"]
     return requests
 
-  types_getDigest = [(IntType, LongType)]
+  types_getDigest = [(int, long)]
 
   @classmethod
   def export_getDigest(cls, requestID):
@@ -328,7 +327,7 @@ class ReqManagerHandler(RequestHandler):
     """
     return cls.__requestDB.getDigest(requestID)
 
-  types_getRequestStatus = [(IntType, LongType)]
+  types_getRequestStatus = [(int, long)]
 
   @classmethod
   def export_getRequestStatus(cls, requestID):
@@ -338,28 +337,19 @@ class ReqManagerHandler(RequestHandler):
       gLogger.error("getRequestStatus: %s" % status["Message"])
     return status
 
-  types_getRequestFileStatus = [[IntType, LongType], list(StringTypes) + [ListType]]
+  types_getRequestFileStatus = [[int, long], [basestring, list]]
 
   @classmethod
   def export_getRequestFileStatus(cls, requestID, lfnList):
     """ get request file status for a given LFNs list and requestID """
-    if isinstance(lfnList, str):
+    if isinstance(lfnList, basestring):
       lfnList = [lfnList]
     res = cls.__requestDB.getRequestFileStatus(requestID, lfnList)
     if not res["OK"]:
       gLogger.error("getRequestFileStatus: %s" % res["Message"])
     return res
 
-#   types_getRequestName = [ ( IntType, LongType ) ]
-#   @classmethod
-#   def export_getRequestName( cls, requestID ):
-#     """ get request name for a given requestID """
-#     requestName = cls.__requestDB.getRequestName( requestID )
-#     if not requestName["OK"]:
-#       gLogger.error( "getRequestName: %s" % requestName["Message"] )
-#     return requestName
-
-  types_getRequestInfo = [[IntType, LongType]]
+  types_getRequestInfo = [[int, long]]
 
   @classmethod
   def export_getRequestInfo(cls, requestID):

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -28,7 +28,7 @@ __RCSID__ = "$Id$"
 
 # # imports
 import os
-from types import  StringTypes
+from types import StringTypes
 try:
   from hashlib import md5
 except ImportError:
@@ -42,19 +42,23 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
+from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
+from DIRAC.RequestManagementSystem.Client.Request import Request
 
 
-def initializeReqProxyHandler( serviceInfo ):
+def initializeReqProxyHandler(serviceInfo):
   """ init RequestProxy handler
 
   :param serviceInfo: whatever
   """
-  gLogger.info( "Initalizing ReqProxyHandler" )
-  gThreadScheduler.addPeriodicTask( 120, ReqProxyHandler.sweeper )
+  gLogger.info("Initalizing ReqProxyHandler")
+  gThreadScheduler.addPeriodicTask(120, ReqProxyHandler.sweeper)
   return S_OK()
 
 ########################################################################
-class ReqProxyHandler( RequestHandler ):
+
+
+class ReqProxyHandler(RequestHandler):
   """
   .. class:: ReqProxyHandler
 
@@ -64,81 +68,80 @@ class ReqProxyHandler( RequestHandler ):
   __requestManager = None
   __cacheDir = None
 
-  def initialize( self ):
+  def initialize(self):
     """ service initialization
 
     :param self: self reference
     """
-    gLogger.notice( "CacheDirectory: %s" % self.cacheDir() )
-    gMonitor.registerActivity( "reqSwept", "Request successfully swept",
-                               "ReqProxy", "Requests/min", gMonitor.OP_SUM )
-    gMonitor.registerActivity( "reqFailed", "Request forward failed",
-                               "ReqProxy", "Requests/min", gMonitor.OP_SUM )
-    gMonitor.registerActivity( "reqReceived", "Request received",
-                               "ReqProxy", "Requests/min", gMonitor.OP_SUM )
+    gLogger.notice("CacheDirectory: %s" % self.cacheDir())
+    gMonitor.registerActivity("reqSwept", "Request successfully swept",
+                              "ReqProxy", "Requests/min", gMonitor.OP_SUM)
+    gMonitor.registerActivity("reqFailed", "Request forward failed",
+                              "ReqProxy", "Requests/min", gMonitor.OP_SUM)
+    gMonitor.registerActivity("reqReceived", "Request received",
+                              "ReqProxy", "Requests/min", gMonitor.OP_SUM)
     return S_OK()
 
   @classmethod
-  def requestManager( cls ):
+  def requestManager(cls):
     """ get request manager """
     if not cls.__requestManager:
-      cls.__requestManager = RPCClient( "RequestManagement/ReqManager" )
+      cls.__requestManager = RPCClient("RequestManagement/ReqManager")
     return cls.__requestManager
 
   @classmethod
-  def cacheDir( cls ):
+  def cacheDir(cls):
     """ get cache dir """
     if not cls.__cacheDir:
-      cls.__cacheDir = os.path.abspath( "requestCache" )
-      if not os.path.exists( cls.__cacheDir ):
-        os.mkdir( cls.__cacheDir )
+      cls.__cacheDir = os.path.abspath("requestCache")
+      if not os.path.exists(cls.__cacheDir):
+        os.mkdir(cls.__cacheDir)
     return cls.__cacheDir
 
   @classmethod
-  def sweeper( cls ):
+  def sweeper(cls):
     """ move cached request to the central request manager
 
     :param self: self reference
     """
     cacheDir = cls.cacheDir()
 
-
     # # cache dir empty?
-    if not os.listdir( cacheDir ):
-      gLogger.always( "sweeper: CacheDir %s is empty, nothing to do" % cacheDir )
+    if not os.listdir(cacheDir):
+      gLogger.always("sweeper: CacheDir %s is empty, nothing to do" % cacheDir)
       return S_OK()
     else:
       # # read 10 cache dir files, the oldest first
-      cachedRequests = [ os.path.abspath( requestFile ) for requestFile in
-                         sorted( filter( os.path.isfile,
-                                         [ os.path.join( cacheDir, requestName )
-                                           for requestName in os.listdir( cacheDir ) ] ),
-                                 key = os.path.getctime ) ][:10]
+      cachedRequests = [os.path.abspath(requestFile) for requestFile in
+                        sorted(filter(os.path.isfile,
+                                      [os.path.join(cacheDir, requestName)
+                                       for requestName in os.listdir(cacheDir)]),
+                               key=os.path.getctime)][:10]
       # # set cached requests to the central RequestManager
       for cachedFile in cachedRequests:
         # # break if something went wrong last time
         try:
-          requestJSON = "".join( open( cachedFile, "r" ).readlines() )
-          cachedRequest = json.loads( requestJSON )
-          cachedName = cachedRequest.get( "RequestName", "***UNKNOWN***" )
-          putRequest = cls.requestManager().putRequest( requestJSON )
+          requestJSON = "".join(open(cachedFile, "r").readlines())
+          cachedRequest = json.loads(requestJSON)
+          cachedName = cachedRequest.get("RequestName", "***UNKNOWN***")
+          putRequest = cls.requestManager().putRequest(requestJSON)
           if not putRequest["OK"]:
-            gLogger.error( "sweeper: unable to set request %s @ ReqManager: %s" % ( cachedName,
-                                                                                    putRequest["Message"] ) )
-            gMonitor.addMark( "reqFailed", 1 )
+            gLogger.error(
+                "sweeper: unable to set request %s @ ReqManager: %s" %
+                (cachedName, putRequest["Message"]))
+            gMonitor.addMark("reqFailed", 1)
 
             continue
-          gLogger.info( "sweeper: successfully put request '%s' @ ReqManager" % cachedName )
-          gMonitor.addMark( "reqSwept", 1 )
-          os.unlink( cachedFile )
+          gLogger.info("sweeper: successfully put request '%s' @ ReqManager" % cachedName)
+          gMonitor.addMark("reqSwept", 1)
+          os.unlink(cachedFile)
         except Exception as error:
-          gMonitor.addMark( "reqFailed", 1 )
-          gLogger.exception( "sweeper: hit by exception", lException = error )
-
+          gMonitor.addMark("reqFailed", 1)
+          gLogger.exception("sweeper: hit by exception", lException=error)
 
       return S_OK()
 
-  def __saveRequest( self, requestName, requestJSON ):
+  def __saveRequest(self, requestName, requestJSON):
     """ save request string to the working dir cache
 
     :param self: self reference
@@ -146,63 +149,73 @@ class ReqProxyHandler( RequestHandler ):
     :param str requestJSON:  request serialized to JSON format
     """
     try:
-      requestFile = os.path.join( self.cacheDir(), md5( requestJSON ).hexdigest() )
-      request = open( requestFile, "w+" )
-      request.write( requestJSON )
+      requestFile = os.path.join(self.cacheDir(), md5(requestJSON).hexdigest())
+      request = open(requestFile, "w+")
+      request.write(requestJSON)
       request.close()
-      return S_OK( requestFile )
-    except OSError, error:
-      err = "unable to dump %s to cache file: %s" % ( requestName, str( error ) )
-      gLogger.exception( err )
-      return S_ERROR( err )
+      return S_OK(requestFile)
+    except OSError as error:
+      err = "unable to dump %s to cache file: %s" % (requestName, str(error))
+      gLogger.exception(err)
+      return S_ERROR(err)
 
   types_getStatus = []
-  def export_getStatus( self ):
+
+  def export_getStatus(self):
     """ get number of requests in cache """
     try:
-      cachedRequests = len( os.listdir( self.cacheDir() ) )
-    except OSError, error:
-      err = "getStatus: unable to list cache dir contents: %s" % str( error )
-      gLogger.exception( err )
-      return S_ERROR( err )
-    return S_OK( cachedRequests )
+      cachedRequests = len(os.listdir(self.cacheDir()))
+    except OSError as error:
+      err = "getStatus: unable to list cache dir contents: %s" % str(error)
+      gLogger.exception(err)
+      return S_ERROR(err)
+    return S_OK(cachedRequests)
 
-  types_putRequest = [ StringTypes ]
-  def export_putRequest( self, requestJSON ):
+  types_putRequest = [StringTypes]
+
+  def export_putRequest(self, requestJSON):
     """ forward request from local RequestDB to central RequestManager
 
     :param self: self reference
     :param str requestType: request type
     """
 
-    gMonitor.addMark( 'reqReceived', 1 )
+    gMonitor.addMark('reqReceived', 1)
 
-    requestDict = json.loads( requestJSON )
-    requestName = requestDict.get( "RequestID", requestDict.get( 'RequestName', "***UNKNOWN***" ) )
-    gLogger.info( "putRequest: got request '%s'" % requestName )
+    requestDict = json.loads(requestJSON)
+    requestName = requestDict.get("RequestID", requestDict.get('RequestName', "***UNKNOWN***"))
+    gLogger.info("putRequest: got request '%s'" % requestName)
 
-    forwardable = self.__forwardable( requestDict )
+    # We only need the object to check the authorization
+    request = Request(requestDict)
+    # Check whether the credentials in the Requests are correct and allowed to be set
+    isAuthorized = RequestValidator.setAndCheckRequestOwner(request, self.getRemoteCredentials())
+
+    if not isAuthorized:
+      return S_ERROR("Credentials in the requests are not allowed")
+
+    forwardable = self.__forwardable(requestDict)
     if not forwardable["OK"]:
-      gLogger.warn( "putRequest: %s" % forwardable["Message"] )
+      gLogger.warn("putRequest: %s" % forwardable["Message"])
 
-
-    setRequest = self.requestManager().putRequest( requestJSON )
+    setRequest = self.requestManager().putRequest(requestJSON)
     if not setRequest["OK"]:
-      gLogger.error( "setReqeuest: unable to set request '%s' @ RequestManager: %s" % ( requestName,
-                                                                                        setRequest["Message"] ) )
+      gLogger.error(
+          "setReqeuest: unable to set request '%s' @ RequestManager: %s" %
+          (requestName, setRequest["Message"]))
       # # put request to the request file cache
-      save = self.__saveRequest( requestName, requestJSON )
+      save = self.__saveRequest(requestName, requestJSON)
       if not save["OK"]:
-        gLogger.error( "setRequest: unable to save request to the cache: %s" % save["Message"] )
+        gLogger.error("setRequest: unable to save request to the cache: %s" % save["Message"])
         return save
-      gLogger.info( "setRequest: %s is saved to %s file" % ( requestName, save["Value"] ) )
-      return S_OK( { "set" : False, "saved" : True } )
+      gLogger.info("setRequest: %s is saved to %s file" % (requestName, save["Value"]))
+      return S_OK({"set": False, "saved": True})
 
-    gLogger.info( "setRequest: request '%s' has been set to the ReqManager" % ( requestName ) )
-    return S_OK( { "set" : True, "saved" : False } )
+    gLogger.info("setRequest: request '%s' has been set to the ReqManager" % (requestName))
+    return S_OK({"set": True, "saved": False})
 
   @staticmethod
-  def __forwardable( requestDict ):
+  def __forwardable(requestDict):
     """ check if request if forwardable
 
     The sub-request of type transfer:putAndRegister, removal:physicalRemoval and removal:reTransfer are
@@ -210,13 +223,19 @@ class ReqProxyHandler( RequestHandler ):
 
     :param str requestJSON: serialized request
     """
-    operations = requestDict.get( "Operations", [] )
+    operations = requestDict.get("Operations", [])
     for operationDict in operations:
-      if operationDict.get( "Type", "" ) in ( "PutAndRegister", "PhysicalRemoval", "ReTransfer" ):
-        return S_ERROR( DErrno.ERMSUKN, "found operation '%s' that cannot be forwarded" % operationDict.get( "Type", "" ) )
+      if operationDict.get("Type", "") in ("PutAndRegister", "PhysicalRemoval", "ReTransfer"):
+        return S_ERROR(
+            DErrno.ERMSUKN,
+            "found operation '%s' that cannot be forwarded" %
+            operationDict.get(
+                "Type",
+                ""))
     return S_OK()
 
   types_listCacheDir = []
+
   def export_listCacheDir(self):
     """List the content of the Cache directory
         :returns: list of file
@@ -226,17 +245,17 @@ class ReqProxyHandler( RequestHandler ):
       dirContent = os.listdir(cacheDir)
       return S_OK(dirContent)
     except OSError as e:
-      return S_ERROR( DErrno.ERMSUKN, "Error listing %s: %s" % ( cacheDir, repr( e ) ) )
+      return S_ERROR(DErrno.ERMSUKN, "Error listing %s: %s" % (cacheDir, repr(e)))
 
-  types_showCachedRequest = [ StringTypes ]
+  types_showCachedRequest = [StringTypes]
+
   def export_showCachedRequest(self, filename):
     """ Show the request cached in the given file """
     fullPath = None
     try:
-      fullPath = os.path.join( self.cacheDir(), filename )
+      fullPath = os.path.join(self.cacheDir(), filename)
       with open(fullPath, 'r') as cacheFile:
-        requestJSON = "".join( cacheFile.readlines() )
-        return S_OK( requestJSON )
+        requestJSON = "".join(cacheFile.readlines())
+        return S_OK(requestJSON)
     except Exception as e:
-      return S_ERROR( DErrno.ERMSUKN, "Error showing cached request %s: %s" % ( fullPath, repr( e ) ) )
-
+      return S_ERROR(DErrno.ERMSUKN, "Error showing cached request %s: %s" % (fullPath, repr(e)))

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -191,7 +191,7 @@ class ReqProxyHandler(RequestHandler):
     isAuthorized = RequestValidator.setAndCheckRequestOwner(request, self.getRemoteCredentials())
 
     if not isAuthorized:
-      return S_ERROR("Credentials in the requests are not allowed")
+      return S_ERROR(DErrno.ENOAUTH, "Credentials in the requests are not allowed")
 
     forwardable = self.__forwardable(requestDict)
     if not forwardable["OK"]:

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -150,9 +150,8 @@ class ReqProxyHandler(RequestHandler):
     """
     try:
       requestFile = os.path.join(self.cacheDir(), md5(requestJSON).hexdigest())
-      request = open(requestFile, "w+")
-      request.write(requestJSON)
-      request.close()
+      with open(requestFile, "w+") as request:
+        request.write(requestJSON)
       return S_OK(requestFile)
     except OSError as error:
       err = "unable to dump %s to cache file: %s" % (requestName, str(error))

--- a/RequestManagementSystem/private/RequestValidator.py
+++ b/RequestManagementSystem/private/RequestValidator.py
@@ -61,12 +61,13 @@ __RCSID__ = "$Id$"
 import inspect
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig, gLogger
+from DIRAC.Core.Security.Properties import FULL_DELEGATION, LIMITED_DELEGATION
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
 
 ########################################################################
-class RequestValidator( object ):
+class RequestValidator(object):
   """
   .. class:: RequestValidator
 
@@ -77,45 +78,50 @@ class RequestValidator( object ):
   __metaclass__ = DIRACSingleton
 
   # # dict with required attrs
-  reqAttrs = { "ForwardDISET" : { "Operation": [ "Arguments" ], "Files" : [] },
-               "PutAndRegister" : { "Operation" : [ "TargetSE" ], "Files" : [ "LFN", "PFN" ] },
-               "ReplicateAndRegister" : { "Operation" : [ "TargetSE" ], "Files" : [ "LFN" ] },
-               "PhysicalRemoval" : { "Operation" : ["TargetSE" ], "Files" : [ "PFN" ] },
-               "RemoveFile" : { "Operation" : [], "Files" : [ "LFN" ] },
-               "RemoveReplica" : { "Operation" : [ "TargetSE" ], "Files" : [ "LFN" ] },
-               "ReTransfer" : { "Operation" : [ "TargetSE" ], "Files" : [ "LFN", "PFN" ] },
-               "RegisterFile" : { "Operation" : [ ], "Files" : [ "LFN", "PFN", "ChecksumType", "Checksum", "GUID" ] },
-               "RegisterReplica" : { "Operation" : [ "TargetSE" ], "Files" : [ "LFN", "PFN" ] } }
+  reqAttrs = {
+      "ForwardDISET": {
+          "Operation": ["Arguments"], "Files": []}, "PutAndRegister": {
+          "Operation": ["TargetSE"], "Files": [
+              "LFN", "PFN"]}, "ReplicateAndRegister": {
+          "Operation": ["TargetSE"], "Files": ["LFN"]}, "PhysicalRemoval": {
+          "Operation": ["TargetSE"], "Files": ["PFN"]}, "RemoveFile": {
+              "Operation": [], "Files": ["LFN"]}, "RemoveReplica": {
+          "Operation": ["TargetSE"], "Files": ["LFN"]}, "ReTransfer": {
+                  "Operation": ["TargetSE"], "Files": [
+                      "LFN", "PFN"]}, "RegisterFile": {
+          "Operation": [], "Files": [
+              "LFN", "PFN", "ChecksumType", "Checksum", "GUID"]}, "RegisterReplica": {
+          "Operation": ["TargetSE"], "Files": [
+              "LFN", "PFN"]}}
 
   # All the operationHandlers defined in the CS
   opHandlers = set()
 
-  def __init__( self ):
+  def __init__(self):
     """ c'tor
 
     just setting validation order
     """
-    self.validator = ( self._hasRequestName,
-                       self._hasOwner,
-                       self._hasOperations,
-                       self._hasType,
-                       self._hasFiles,
-                       self._hasRequiredAttrs,
-                       self._hasChecksumAndChecksumType )
+    self.validator = (self._hasRequestName,
+                      self._hasOwner,
+                      self._hasOperations,
+                      self._hasType,
+                      self._hasFiles,
+                      self._hasRequiredAttrs,
+                      self._hasChecksumAndChecksumType)
 
-    configPath = PathFinder.getAgentSection( "RequestManagement/RequestExecutingAgent" )
+    configPath = PathFinder.getAgentSection("RequestManagement/RequestExecutingAgent")
 
     # # operation handlers over here
-    opHandlersPath = "%s/%s" % ( configPath, "OperationHandlers" )
-    opHandlers = gConfig.getSections( opHandlersPath )
+    opHandlersPath = "%s/%s" % (configPath, "OperationHandlers")
+    opHandlers = gConfig.getSections(opHandlersPath)
     if not opHandlers["OK"]:
-      gLogger.error( opHandlers["Message" ] )
+      gLogger.error(opHandlers["Message"])
     else:
-      self.opHandlers = set( opHandlers["Value"] )
-
+      self.opHandlers = set(opHandlers["Value"])
 
   @classmethod
-  def addReqAttrsCheck( cls, operationType, operationAttrs = None, filesAttrs = None ):
+  def addReqAttrsCheck(cls, operationType, operationAttrs=None, filesAttrs=None):
     """ add required attributes of Operation of type :operationType:
 
     :param str operationType: Operation.Type
@@ -124,124 +130,172 @@ class RequestValidator( object ):
     :param filesAttrs: required Files attributes
     :type filesAttrs: python:list
     """
-    toUpdate = { "Operation" : operationAttrs if operationAttrs else [],
-                 "Files" : filesAttrs if filesAttrs else [] }
+    toUpdate = {"Operation": operationAttrs if operationAttrs else [],
+                "Files": filesAttrs if filesAttrs else []}
     if operationType not in cls.reqAttrs:
-      cls.reqAttrs[operationType] = { "Operation" : [], "Files" : [] }
+      cls.reqAttrs[operationType] = {"Operation": [], "Files": []}
     for key, attrList in cls.reqAttrs[operationType].items():
-      cls.reqAttrs[operationType][key] = list( set( attrList + toUpdate[key] ) )
+      cls.reqAttrs[operationType][key] = list(set(attrList + toUpdate[key]))
 
   @classmethod
-  def addValidator( cls, fcnObj ):
+  def addValidator(cls, fcnObj):
     """ add `fcnObj` validator """
-    if not callable( fcnObj ):
-      return S_ERROR( "supplied argument is not callable" )
-    args = inspect.getargspec( fcnObj ).args
-    if len( args ) not in ( 1, 2 ):
-      return S_ERROR( "wrong number of arguments for supplied function object" )
-    cls.validator = cls.validator + tuple( fcnObj, )
+    if not callable(fcnObj):
+      return S_ERROR("supplied argument is not callable")
+    args = inspect.getargspec(fcnObj).args
+    if len(args) not in (1, 2):
+      return S_ERROR("wrong number of arguments for supplied function object")
+    cls.validator = cls.validator + tuple(fcnObj, )
     return S_OK()
 
-  def validate( self, request ):
+  def validate(self, request):
     """ validation of a given `request`
 
     :param ~Request.Request request: Request instance
     """
     for validator in self.validator:
-      isValid = validator( request )
+      isValid = validator(request)
       if not isValid["OK"]:
         return isValid
     # # if we're here request is more or less valid
     return S_OK()
 
   @staticmethod
-  def _hasDIRACSetup( request ):
+  def _hasDIRACSetup(request):
     """ required attribute - DIRACSetup """
     if not request.DIRACSetup:
-      return S_ERROR( "DIRACSetup not set" )
+      return S_ERROR("DIRACSetup not set")
     return S_OK()
 
   @staticmethod
-  def _hasOwner( request ):
+  def _hasOwner(request):
     """ required attributes OwnerDn and OwnerGroup """
     if not request.OwnerDN:
-      return S_ERROR( "Request '%s' is missing OwnerDN value" % request.RequestName )
+      return S_ERROR("Request '%s' is missing OwnerDN value" % request.RequestName)
     if not request.OwnerGroup:
-      return S_ERROR( "Request '%s' is missing OwnerGroup value" % request.RequestName )
+      return S_ERROR("Request '%s' is missing OwnerGroup value" % request.RequestName)
     return S_OK()
 
   @staticmethod
-  def _hasRequestName( request ):
+  def _hasRequestName(request):
     """ required attribute: RequestName """
     if not request.RequestName:
-      return S_ERROR( "RequestName not set" )
+      return S_ERROR("RequestName not set")
     return S_OK()
 
   @staticmethod
-  def _hasOperations( request ):
+  def _hasOperations(request):
     """ at least one operation is in """
-    if not len( request ):
-      return S_ERROR( "Operations not present in request '%s'" % request.RequestName )
+    if not len(request):
+      return S_ERROR("Operations not present in request '%s'" % request.RequestName)
     return S_OK()
 
   @staticmethod
-  def _hasType( request ):
+  def _hasType(request):
     """ operation type is set """
     for operation in request:
       if not operation.Type:
-        return S_ERROR( "Operation #%d in request '%s' hasn't got Type set" % ( request.indexOf( operation ),
-                                                                               request.RequestName ) )
+        return S_ERROR("Operation #%d in request '%s' hasn't got Type set" %
+                       (request.indexOf(operation), request.RequestName))
     return S_OK()
 
   @classmethod
-  def _hasFiles( cls, request ):
+  def _hasFiles(cls, request):
     """ check for files presence """
     for operation in request:
       if operation.Type not in cls.reqAttrs:
         return S_OK()
-      if cls.reqAttrs[operation.Type]["Files"] and not len( operation ):
-        return S_ERROR( "Operation #%d of type '%s' hasn't got files to process." % ( request.indexOf( operation ),
-                                                                                      operation.Type ) )
-      if not cls.reqAttrs[operation.Type]["Files"] and len( operation ):
-        return S_ERROR( "Operation #%d of type '%s' has got files to process." % ( request.indexOf( operation ),
-                                                                                   operation.Type ) )
+      if cls.reqAttrs[operation.Type]["Files"] and not len(operation):
+        return S_ERROR(
+            "Operation #%d of type '%s' hasn't got files to process." %
+            (request.indexOf(operation), operation.Type))
+      if not cls.reqAttrs[operation.Type]["Files"] and len(operation):
+        return S_ERROR(
+            "Operation #%d of type '%s' has got files to process." %
+            (request.indexOf(operation), operation.Type))
     return S_OK()
 
   @classmethod
-  def _hasRequiredAttrs( cls, request ):
+  def _hasRequiredAttrs(cls, request):
     """ check required attributes for operations and files """
     for operation in request:
       if operation.Type in cls.reqAttrs:
         opAttrs = cls.reqAttrs[operation.Type]["Operation"]
         for opAttr in opAttrs:
-          if not getattr( operation, opAttr ):
-            return S_ERROR( "Operation #%d of type '%s' is missing %s attribute." % \
-                             ( request.indexOf( operation ), operation.Type, opAttr ) )
+          if not getattr(operation, opAttr):
+            return S_ERROR("Operation #%d of type '%s' is missing %s attribute." %
+                           (request.indexOf(operation), operation.Type, opAttr))
         fileAttrs = cls.reqAttrs[operation.Type]["Files"]
         for opFile in operation:
           for fileAttr in fileAttrs:
-            if not getattr( opFile, fileAttr ):
-              return S_ERROR( "Operation #%d of type '%s' is missing %s attribute for file." % \
-                               ( request.indexOf( operation ), operation.Type, fileAttr ) )
+            if not getattr(opFile, fileAttr):
+              return S_ERROR("Operation #%d of type '%s' is missing %s attribute for file." %
+                             (request.indexOf(operation), operation.Type, fileAttr))
     return S_OK()
 
   @classmethod
-  def _hasChecksumAndChecksumType( cls, request ):
+  def _hasChecksumAndChecksumType(cls, request):
     """ Checksum and ChecksumType should be specified """
     for operation in request:
       for opFile in operation:
-        if any( [ opFile.Checksum, opFile.ChecksumType ] ) and not all( [opFile.Checksum, opFile.ChecksumType ] ):
-          return S_ERROR( "File in operation #%d is missing Checksum (%s) or ChecksumType (%s)" % \
-                          ( request.indexOf( operation ), opFile.Checksum, opFile.ChecksumType ) )
+        if any([opFile.Checksum, opFile.ChecksumType]) and not all(
+                [opFile.Checksum, opFile.ChecksumType]):
+          return S_ERROR("File in operation #%d is missing Checksum (%s) or ChecksumType (%s)" %
+                         (request.indexOf(operation), opFile.Checksum, opFile.ChecksumType))
     return S_OK()
 
-
-  def _hasExistingOperationTypes( self, request ):
+  def _hasExistingOperationTypes(self, request):
     """ Check that there is a handler defined in the CS for each operation type"""
-    requiredHandlers = set( [op.Type for op in request] )
+    requiredHandlers = set([op.Type for op in request])
     nonExistingHandlers = requiredHandlers - self.opHandlers
 
     if nonExistingHandlers:
-      return S_ERROR( "The following operation type(s) have no handlers defined in the CS: %s" % nonExistingHandlers )
+      return S_ERROR(
+          "The following operation type(s) have no handlers defined in the CS: %s" %
+          nonExistingHandlers)
 
     return S_OK()
+
+  @staticmethod
+  def setAndCheckRequestOwner(request, remoteCredentials):
+    """
+        CAUTION: meant to be called on the server side.
+                (does not make much sense otherwise)
+
+        Sets the ownerDN and ownerGroup of the Request from
+        the client's credentials.
+
+        If they are already set, make sure the client is allowed to do so
+        (FULL_DELEGATION or LIMITED_DELEGATION). This is the case of pilots or
+        the RequestExecutingAgent
+
+        :param request: the request to test
+        :param remoteCredentials: credentials from the clients
+
+        :returns: True if everything is fine, False otherwise
+    """
+
+    credDN = remoteCredentials['DN']
+    credGroup = remoteCredentials['group']
+    credProperties = remoteCredentials['properties']
+
+    # If the owner or the group was not set, we use the one of the credentials
+    if not request.OwnerDN or not request.OwnerGroup:
+      request.OwnerDN = credDN
+      request.OwnerGroup = credGroup
+      return True
+
+    # From here onward, we expect the ownerDN/group to already have a value
+
+    # If the credentials in the Request match those from the credentials, it's OK
+    if request.OwnerDN == credDN and request.OwnerGroup == credGroup:
+      return True
+
+    # From here, something/someone is putting a request on behalf of someone else
+
+    # Only allow this if the credentials have Full or Limited delegation properties
+
+    if FULL_DELEGATION in credProperties or LIMITED_DELEGATION in credProperties:
+      return True
+
+    return False

--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -987,7 +987,7 @@ WHERE j.JobId = %s AND t.TQId = j.TQId" %
       return result
     return self.retrieveTaskQueues([tqTuple[0] for tqTuple in result['Value']])
 
-  def retrieveTaskQueues(self, tqIdList=False):
+  def retrieveTaskQueues(self, tqIdList=None):
     """
     Get all the task queues
     """
@@ -998,8 +998,9 @@ WHERE j.JobId = %s AND t.TQId = j.TQId" %
       sqlGroupEntries.append("`tq_TaskQueues`.%s" % field)
     sqlCmd = "SELECT %s FROM `tq_TaskQueues`, `tq_Jobs`" % ", ".join(sqlSelectEntries)
     sqlTQCond = ""
-    if tqIdList:
+    if tqIdList is not None:
       if not tqIdList:
+        # Empty list => Fast-track no matches
         return S_OK({})
       else:
         sqlTQCond += " AND `tq_TaskQueues`.TQId in ( %s )" % ", ".join([str(id_) for id_ in tqIdList])

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -196,6 +196,9 @@ class JobManagerHandler(RequestHandler):
 
     result['JobID'] = result['Value']
     result['requireProxyUpload'] = self.__checkIfProxyUploadIsRequired()
+    # Ensure non-parametric jobs (i.e. non-bulk) get sent to optimizer immediately
+    if not parametricJob:
+      self.__sendJobsToOptimizationMind(jobIDList)
     return result
 
 ###########################################################################

--- a/release.notes
+++ b/release.notes
@@ -1,3 +1,10 @@
+[v6r20p1]
+
+*WorkloadManagementSystem
+
+FIX: (#3697) Ensure retrieveTaskQueues doesn't return anything when given an empty list of TQ IDs.
+FIX: (#3698) Call optimizer fast-path for non-bulk jobs
+
 [v6r20]
 
 *Core

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -17,6 +17,7 @@ from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 from DIRAC.RequestManagementSystem.Client.File import File
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
+from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 
 from DIRAC.RequestManagementSystem.DB.RequestDB import RequestDB
 
@@ -50,10 +51,11 @@ class ReqClientTestCase(unittest.TestCase):
     self.operation.addFile(self.file)
     self.operation.addFile(self.file2)
 
+    proxyInfo = getProxyInfo()['Value']
     self.request = Request()
     self.request.RequestName = "RequestManagerHandlerTests"
-    self.request.OwnerDN = "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=cibak/CN=605919/CN=Krzysztof Ciba"
-    self.request.OwnerGroup = "dirac_user"
+    self.request.OwnerDN = proxyInfo['identity']
+    self.request.OwnerGroup = proxyInfo['group']
     self.request.JobID = 123
     self.request.addOperation(self.operation)
 
@@ -88,7 +90,7 @@ class ReqClientMix(ReqClientTestCase):
 
   def test01fullChain(self):
     put = self.requestClient.putRequest(self.request)
-    self.assertTrue(put['OK'])
+    self.assertTrue(put['OK'], put)
 
     self.assertEqual(type(put['Value']), long)
     reqID = put['Value']
@@ -128,11 +130,12 @@ class ReqClientMix(ReqClientTestCase):
     self.assertEqual(res['OK'], True, res['Message'] if 'Message' in res else 'OK')
     self.assertTrue(isinstance(res['Value']['Successful'][123], Request))
 
+    proxyInfo = getProxyInfo()['Value']
     # Adding new request
     request2 = Request()
     request2.RequestName = "RequestManagerHandlerTests-2"
-    request2.OwnerDN = "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=cibak/CN=605919/CN=Krzysztof Ciba"
-    request2.OwnerGroup = "dirac_user"
+    self.request.OwnerDN = proxyInfo['identity']
+    self.request.OwnerGroup = proxyInfo['group']
     request2.JobID = 456
     request2.addOperation(self.operation)
 
@@ -206,7 +209,8 @@ class ReqClientMix(ReqClientTestCase):
       self.assertEqual(put["OK"], True)
       reqIDs.append(put['Value'])
 
-    loops = self.stressRequests // self.bulkRequest + (1 if (self.stressRequests % self.bulkRequest) else 0)
+    loops = self.stressRequests // self.bulkRequest + \
+        (1 if (self.stressRequests % self.bulkRequest) else 0)
     totalSuccessful = 0
 
     time.sleep(1)
@@ -224,9 +228,12 @@ class ReqClientMix(ReqClientTestCase):
 
     print "getRequests duration %s " % (endTime - startTime)
 
-    self.assertEqual(totalSuccessful,
-                     self.stressRequests,
-                     "Did not retrieve all the requests: %s instead of %s" % (totalSuccessful, self.stressRequests))
+    self.assertEqual(
+        totalSuccessful,
+        self.stressRequests,
+        "Did not retrieve all the requests: %s instead of %s" %
+        (totalSuccessful,
+         self.stressRequests))
 
     for reqID in reqIDs:
       delete = db.deleteRequest(reqID)
@@ -239,7 +246,8 @@ class ReqClientMix(ReqClientTestCase):
 
     req = Request({"RequestName": "FTSTest"})
     op = Operation({"Type": "ReplicateAndRegister", "TargetSE": "CERN-USER"})
-    op += File({"LFN": "/a/b/c", "Status": "Scheduled", "Checksum": "123456", "ChecksumType": "ADLER32"})
+    op += File({"LFN": "/a/b/c", "Status": "Scheduled",
+                "Checksum": "123456", "ChecksumType": "ADLER32"})
     req += op
 
     put = db.putRequest(req)
@@ -268,13 +276,16 @@ class ReqClientMix(ReqClientTestCase):
     r.RequestName = "dirty"
 
     op1 = Operation({"Type": "ReplicateAndRegister", "TargetSE": "CERN-USER"})
-    op1 += File({"LFN": "/a/b/c/1", "Status": "Scheduled", "Checksum": "123456", "ChecksumType": "ADLER32"})
+    op1 += File({"LFN": "/a/b/c/1", "Status": "Scheduled",
+                 "Checksum": "123456", "ChecksumType": "ADLER32"})
 
     op2 = Operation({"Type": "ReplicateAndRegister", "TargetSE": "CERN-USER"})
-    op2 += File({"LFN": "/a/b/c/2", "Status": "Scheduled", "Checksum": "123456", "ChecksumType": "ADLER32"})
+    op2 += File({"LFN": "/a/b/c/2", "Status": "Scheduled",
+                 "Checksum": "123456", "ChecksumType": "ADLER32"})
 
     op3 = Operation({"Type": "ReplicateAndRegister", "TargetSE": "CERN-USER"})
-    op3 += File({"LFN": "/a/b/c/3", "Status": "Scheduled", "Checksum": "123456", "ChecksumType": "ADLER32"})
+    op3 += File({"LFN": "/a/b/c/3", "Status": "Scheduled",
+                 "Checksum": "123456", "ChecksumType": "ADLER32"})
 
     r += op1
     r += op2
@@ -302,7 +313,8 @@ class ReqClientMix(ReqClientTestCase):
     self.assertEqual(len(r), 2, "2. len wrong")
 
     op4 = Operation({"Type": "ReplicateAndRegister", "TargetSE": "CERN-USER"})
-    op4 += File({"LFN": "/a/b/c/4", "Status": "Scheduled", "Checksum": "123456", "ChecksumType": "ADLER32"})
+    op4 += File({"LFN": "/a/b/c/4", "Status": "Scheduled",
+                 "Checksum": "123456", "ChecksumType": "ADLER32"})
 
     r[0] = op4
     put = db.putRequest(r)
@@ -317,6 +329,19 @@ class ReqClientMix(ReqClientTestCase):
 
     delete = db.deleteRequest(reqID)
     self.assertEqual(delete["OK"], True, delete['Message'] if 'Message' in delete else 'OK')
+
+  def test07Authorization(self):
+    """ Test whether request sets on behalf of others are rejected"""
+
+    request = Request({"RequestName": "unauthorized"})
+    request.OwnerDN = 'NotMe'
+    request.OwnerDN = 'AnotherGroup'
+    op = Operation({"Type": "RemoveReplica", "TargetSE": "CERN-USER"})
+    op += File({"LFN": "/lhcb/user/c/cibak/foo"})
+    request += op
+    res = self.requestClient.putRequest(request)
+
+    self.assertFalse(res['OK'], res)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The idea is the following:
* the RPC stub is never used except for ForwardDISET
* in the RPC stub, do not resolve the user/group
* When executing FowardDISET, use the owner/group of the Request 
* In the RMS (ReqManager and ReqProxy), check whether the owner/group of the Request are the same as the client
* If not, (RequestExecutingAgent, pilot sending AccountingRequest), make sure that the client has either FULL_DELEGATION or LIMITED_DELEGATION properties

If everyone is ok, then we update the doc so that it reflects the need for the properties to use the RMS

@fstagni @andresailer @atsareg @zmathe 

RMS integration tests were updated, some tests were done on FORWARD diset by Simon. We still need better testing (LHCb certification for example)
